### PR TITLE
EZYC-2838 :sparkles: Raise min password length from 8 to 12 characters.

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
@@ -40,7 +40,7 @@
     },
     "IdentityOptions": {
         "Password": {
-            "RequiredLength": 8
+            "RequiredLength": 12
         },
         "User": {
             "RequireUniqueEmail": true

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -65,7 +65,7 @@
     "BasePath": "",
     "IdentityOptions": {
         "Password": {
-            "RequiredLength": 8
+            "RequiredLength": 12
         },
         "User": {
             "RequireUniqueEmail": true

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -88,7 +88,7 @@
   "BasePath": "",
   "IdentityOptions": {
     "Password": {
-      "RequiredLength": 8
+      "RequiredLength": 12
     },
     "User": {
       "RequireUniqueEmail": true


### PR DESCRIPTION
passwords for new users are already required to have upper cased, numerical and special characters.