### PR TITLE
EZYC-4090 :gear: Set default account lockout settings

### DIFF
--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -96,6 +96,10 @@
     },
     "SignIn": {
       "RequireConfirmedAccount": false
+    },
+    "Lockout": {
+      "MaxFailedAccessAttempts": 5,
+      "DefaultLockoutTimeSpan": "00:30:00"
     }
   },
 


### PR DESCRIPTION
This is required by PCI DSS