### PR TITLE
Feature/ezyc 4280/allow invalid ssl

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Configuration/AdminConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/AdminConfiguration.cs
@@ -22,7 +22,7 @@
         public string CustomThemeCss { get; set; }
 
         // EZY-modification (EZYC-3029): below our custom settings
-        public bool IdentityServerBaseUrlAllowInvalidSsl { get; set; }
+        public bool IdentityServerAllowInvalidSsl { get; set; }
         public bool IdentityServerUseExternalBaseUrl { get; set; }
         public string IdentityServerExternalBaseUrl { get; set; }
         public string ApplicationName { get; set; } = "Id.Admin";

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -409,7 +409,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
                     .AddOpenIdConnect(AuthenticationConsts.OidcAuthenticationScheme, options =>
                     {
                         options.Authority = adminConfiguration.IdentityServerBaseUrl;
-                        if (adminConfiguration.IdentityServerBaseUrlAllowInvalidSsl)
+                        if (adminConfiguration.IdentityServerAllowInvalidSsl)
                         {
                             options.BackchannelHttpHandler =new HttpClientHandler
                             {

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -34,7 +34,7 @@
         "HideUIForMSSqlErrorLogging": false,
 
         // EZY-modification (EZYC-3029): our custom settings
-        "IdentityServerBaseUrlAllowInvalidSsl": false,
+        "IdentityServerAllowInvalidSsl": false,
         "IdentityServerExternalBaseUrl": "",
         "IdentityServerUseExternalBaseUrl": false,
         "ShowPii": false


### PR DESCRIPTION
Allow admin -> sts connectivity in environmenths that have invalid SSL cert and can't use HTTP.
GCP CERT & PROD with sabre-gcp.com domain is such and we can't use public, sabre.com domains yet. So we have to allow it.
This setting is disabled by default so no breaking change