### PR TITLE
cicd/RADEZYC-5149/do-not-allow-override-artifacts-with-same-version

### DIFF
--- a/build/restore-ezyBuild.csproj
+++ b/build/restore-ezyBuild.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <!-- We just need to pull the ezyBuild package for build process to work -->
   <ItemGroup>
-    <PackageReference Include="ezyBuild" Version="2.0.13" />
+    <PackageReference Include="ezyBuild" Version="2.0.18" />
   </ItemGroup>
 </Project>

--- a/build/restore-ezyBuild.csproj
+++ b/build/restore-ezyBuild.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <!-- We just need to pull the ezyBuild package for build process to work -->
   <ItemGroup>
-    <PackageReference Include="ezyBuild" Version="2.0.19" />
+    <PackageReference Include="ezyBuild" Version="2.0.21" />
   </ItemGroup>
 </Project>

--- a/build/restore-ezyBuild.csproj
+++ b/build/restore-ezyBuild.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <!-- We just need to pull the ezyBuild package for build process to work -->
   <ItemGroup>
-    <PackageReference Include="ezyBuild" Version="2.0.18" />
+    <PackageReference Include="ezyBuild" Version="2.0.19" />
   </ItemGroup>
 </Project>

--- a/build/restore-ezyBuild.csproj
+++ b/build/restore-ezyBuild.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <!-- We just need to pull the ezyBuild package for build process to work -->
   <ItemGroup>
-    <PackageReference Include="ezyBuild" Version="2.0.21" />
+    <PackageReference Include="ezyBuild" Version="2.0.22" />
   </ItemGroup>
 </Project>

--- a/run-tcagent-win.rb
+++ b/run-tcagent-win.rb
@@ -77,7 +77,7 @@ $container_engine = ENV["CONTAINER_ENGINE"] || "docker"
 puts "CONTAINER_ENGINE: #{$container_engine}"
 container_name = "ezy-tc-agent-local-#{current_dir_name}-#{$container_engine}"
 tcagent_extra_env_vars = ($container_engine == "docker") ? "-e DOCKER_IN_DOCKER=start" : ""
-tcagent_image = ($container_engine == "docker") ? "ezy.teamcity.agent:2023.11.4-linux-sudo-6" : "ezy.teamcity.agent:2023.05.4-linux-1"
+tcagent_image = ($container_engine == "docker") ? "ezy.teamcity.agent" : "ezy.teamcity.agent:2023.05.4-linux-1"
 # * Podman: As a non-root container user, container images are stored under your home directory ($HOME/.local/share/containers/storage/), instead of /var/lib/containers.
 #   https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/managing_containers/finding_running_and_building_containers_with_podman_skopeo_and_buildah
 #   Unfortunately, mounting this drive on Windwos (nfs fs) makes the directory owned by root, so not usable inside. The workaround would be to create
@@ -96,6 +96,7 @@ task :default do
   else
     puts "Container #{container_name} does not exist, need to create it"
     sh "docker run -it -d \
+      --pull=always \
       --privileged \
       --name #{container_name} \
       #{tcagent_extra_env_vars} \

--- a/run-tcagent-win.rb
+++ b/run-tcagent-win.rb
@@ -1,19 +1,10 @@
-# * Allows testing all rake commands inside teamcity build agent docker image, so in exactly same environment as Remotely.
-# * Since ezyBuild-1.0.153 version, execution of rake commands directly on windows IS NO LONGER SUPPORTED!
-# * DO NOT connect to current teamcity server using this script (leave the SERVER_URL as is)#
-#   To do that, use the src\projects\ezyTeamCityAgent\run-tc-agent-local.bat script
 # * Environment Variables: All env vars are mounted in the /opt/.ezyBuild/env folder, to be later mounted further in eventual worker-containers with --env-file param.
 #     This is to not need to keep secrest in ENV vars in the main tc agent image (they are all visible .e.g in the TC UI page for the agent)
-# * Docker registries config: mounted to /home/buildagent/.docker/config.json allows access to registries (GCR & Nexus).
 # * RUN_INNER_CONTAINERS_AS_ROOT=false. When mounting our sources into /app from Windows, passing the $(id -u):$(id -g) to inner containers work well - i.e.
 #   they don't complain about not enough permissions to create dirs or files.
-# * Plugging directories for TC-related diagnosis
-#   -v #{project_dot_ezy_build_dir}/.tc/ezy-tc-agent-local-#{current_dir_name}/conf:/data/teamcity_agent/conf \
-#   -v #{project_dot_ezy_build_dir}/.tc/ezy-tc-agent-local-#{current_dir_name}/work":/opt/buildagent/work \
-#   -v #{project_dot_ezy_build_dir}/.tc/ezy-tc-agent-local-#{current_dir_name}/temp":/opt/buildagent/temp \
-#   -v #{project_dot_ezy_build_dir}/.tc/ezy-tc-agent-local-#{current_dir_name}/tools":/opt/buildagent/tools \
-#   -v #{project_dot_ezy_build_dir}/.tc/ezy-tc-agent-local-#{current_dir_name}/plugins":/opt/buildagent/plugins \
-#   -v #{project_dot_ezy_build_dir}/.tc/ezy-tc-agent-local-#{current_dir_name}/system":/opt/buildagent/system \
+# * To preserve the history, we instruct it to be saved into mounted folder by HISTFILE env var, but also have to add "-e HISTCONTROL=histappend".
+#   This is because we firstly detach from session (in background) and attach to it via exec (so that we can attach to it later on). 
+#   Also -it options has to be present, even in the first container start to allow the history to be saved to file.
 #
 # * Where to get secrets from?:
 #   * GCR_USERNAME: ezydeploy"
@@ -30,7 +21,7 @@
 #   * AWS_DEFAULT_REGION="us-east-1"
 #   * AWS_ACCESS_KEY_ID=""
 #   * AWS_SECRET_ACCESS_KEY=""
-#   * AWS_SESSION_TOKEN="" - 
+#   * AWS_SESSION_TOKEN="" -
 
 require "base64"
 execution_path = Dir.pwd
@@ -62,16 +53,16 @@ File.write(octopus_sabre_gke_env_file, "OCTOPUS_APIKEY=#{ENV["OCTOPUS_SABRE_GKE_
 # Write .env files for ezyDeploy
 home_dot_ezy_deploy_env_dir = "#{home_dot_ezy_deploy_dir}/.env"
 Dir.mkdir(home_dot_ezy_deploy_env_dir) unless File.exists?(home_dot_ezy_deploy_env_dir)
-aws_ezyradixx_env_file = "#{home_dot_ezy_deploy_env_dir}/aws_ezyradixx.env"
-File.write(aws_ezyradixx_env_file, "AWS_DEFAULT_REGION=#{ENV["AWS_DEFAULT_REGION"]}\nAWS_ACCESS_KEY_ID=#{ENV["AWS_ACCESS_KEY_ID"]}\nAWS_SECRET_ACCESS_KEY=#{ENV["AWS_SECRET_ACCESS_KEY"]}\nAWS_SESSION_TOKEN=#{ENV["AWS_SESSION_TOKEN"]}") unless File.exists?(aws_ezyradixx_env_file)
+aws_env_file = "#{home_dot_ezy_deploy_env_dir}/aws.env"
+File.write(aws_env_file, "AWS_DEFAULT_REGION=#{ENV["AWS_DEFAULT_REGION"]}\nAWS_ACCESS_KEY_ID=#{ENV["AWS_ACCESS_KEY_ID"]}\nAWS_SECRET_ACCESS_KEY=#{ENV["AWS_SECRET_ACCESS_KEY"]}\nAWS_SESSION_TOKEN=#{ENV["AWS_SESSION_TOKEN"]}") unless File.exists?(aws_env_file)
 
-# Assume TF files that will be mounted in tc agent container. 
+# Assume TF files that will be mounted in tc agent container.
 dot_tf_dir = "#{home_dot_ezy_build_dir}/.tf"
 Dir.mkdir(dot_tf_dir) unless File.exists?(dot_tf_dir)
 terraformrc_tf_file = "#{dot_tf_dir}/.terraformrc"
 File.write(terraformrc_tf_file, "credentials \"tfe.prod.sabre-gcp.com\" { token = \"#{ENV["TF_TFE_PROD_TOKEN"]}\" }") unless File.exists?(terraformrc_tf_file)
 
-# Write docker's config file that will be mounted in tc agent container. 
+# Write docker's config file that will be mounted in tc agent container.
 dot_docker_dir = "#{home_dot_ezy_build_dir}/.docker"
 Dir.mkdir(dot_docker_dir) unless File.exists?(dot_docker_dir)
 docker_config_file = "#{dot_docker_dir}/config.json"
@@ -84,42 +75,54 @@ end
 
 $container_engine = ENV["CONTAINER_ENGINE"] || "docker"
 puts "CONTAINER_ENGINE: #{$container_engine}"
+container_name = "ezy-tc-agent-local-#{current_dir_name}-#{$container_engine}"
 tcagent_extra_env_vars = ($container_engine == "docker") ? "-e DOCKER_IN_DOCKER=start" : ""
-tcagent_image = ($container_engine == "docker") ? "ezy.teamcity.agent:2023.11.4-linux-sudo-4" : "ezy.teamcity.agent:2023.05.4-linux-1"
+tcagent_image = ($container_engine == "docker") ? "ezy.teamcity.agent:2023.11.4-linux-sudo-6" : "ezy.teamcity.agent:2023.05.4-linux-1"
 # Podman: As a non-root container user, container images are stored under your home directory ($HOME/.local/share/containers/storage/), instead of /var/lib/containers.
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/managing_containers/finding_running_and_building_containers_with_podman_skopeo_and_buildah
-# Unfortunately, mounting this drive on Windwos (nfs fs) makes the directory owned by root, so not usable inside. The workaround would be to create 
+# Unfortunately, mounting this drive on Windwos (nfs fs) makes the directory owned by root, so not usable inside. The workaround would be to create
 # the volume on host system with buildagent as owner, however this would work only under linux.
 tcagent_mount_container_engine_dir = ($container_engine == "docker") ? "-v #{$container_engine}_volumes_#{current_dir_name}:/var/lib/docker" : ""
 
 task :default do
-  sh "docker run -d \
-        --pull always \
-        --privileged \
-        --name ezy-tc-agent-local-#{current_dir_name}-#{$container_engine} \
-        #{tcagent_extra_env_vars} \
-        -e SERVER_URL=https://do.not.connect \
-        -e AGENT_NAME=ezy-tc-agent-local-#{current_dir_name}-#{$container_engine} \
-        -e CONTAINER_ENGINE=#{$container_engine} \
-        -e RUN_INNER_CONTAINERS_AS_ROOT=false \
-        #{tcagent_mount_container_engine_dir} \
-        -v #{dot_docker_dir}:/home/buildagent/.docker:ro \
-        -v #{home_dot_ezy_build_env_dir}:/opt/.ezyBuild/.env:ro \
-        -v #{dot_tf_dir}:/opt/.ezyBuild/.tf:ro \
-        -v #{home_dot_ezy_deploy_env_dir}:/home/buildagent/.ezyDeploy/.env:ro \
-        -v ezy.gcpcli.gcloud-config:/home/buildagent/.config/gcloud \
-        -v #{execution_path}:/app \
-      ghcr.io/ezywebwerkstaden/#{tcagent_image} > #{project_dot_ezy_build_dir}/.tcagent-local-container-id" 
-
-  # Read container from file and exec into container
-  container_id = text = File.read("#{project_dot_ezy_build_dir}/.tcagent-local-container-id").strip()  
-  begin
-    sh "docker exec -it -w /app #{container_id} /bin/bash"
-  ensure    
-    # To automatically remove tcagent container, uncomment the following section. However, with rootless/podman version we can't mount podman volumes externally 
-    # on Windows, so we lose them once container exits. That's why, it's better to keep it for later re-attachment.
-    # # on exit, clean up by removing the detached container
-    # puts "removing container #{container_id}"
-    # sh "docker rm -f #{container_id}"
+  if container_exists?(container_name)
+    if container_running?(container_name)
+      puts "Container #{container_name} is already created and started, just need to attach"
+    else
+      puts "Container #{container_name} is already created but is not in Running state, need to start it"
+      sh "docker start #{container_name}"
+    end
+  else
+    puts "Container #{container_name} does not exist, need to create it"
+    sh "docker run -it -d \
+      --privileged \
+      --name #{container_name} \
+      #{tcagent_extra_env_vars} \
+      -e START_AGENT=no \
+      -e CONTAINER_ENGINE=#{$container_engine} \
+      -e RUN_INNER_CONTAINERS_AS_ROOT=false \
+      -e HISTFILE=/app/.ezyBuild/.bash_history \
+      -e HISTCONTROL=histappend \
+      #{tcagent_mount_container_engine_dir} \
+      -v #{dot_docker_dir}:/home/buildagent/.docker:ro \
+      -v #{home_dot_ezy_build_env_dir}:/opt/.ezyBuild/.env:ro \
+      -v #{dot_tf_dir}:/opt/.ezyBuild/.tf:ro \
+      -v #{home_dot_ezy_deploy_env_dir}:/home/buildagent/.ezyDeploy/.env:ro \
+      -v ezy.gcpcli.gcloud-config:/home/buildagent/.config/gcloud \
+      -v #{execution_path}:/app \
+      ghcr.io/ezywebwerkstaden/#{tcagent_image}"
   end
+
+  puts "Attaching to: #{container_name}"
+  sh "docker exec -it -w /app #{container_name} /bin/bash"
+end
+
+def container_exists?(container_name)
+  output = `docker ps -a --filter "name=#{container_name}" --format "{{.Names}}"`.strip
+  output == container_name
+end
+
+def container_running?(container_name)
+  status = `docker inspect --format={{.State.Running}} #{container_name} 2>nul`
+  status.strip == "true"
 end

--- a/run-tcagent-win.rb
+++ b/run-tcagent-win.rb
@@ -7,14 +7,14 @@
 #   Also -it options has to be present, even in the first container start to allow the history to be saved to file.
 #
 # * Where to get secrets from?:
-#   * GCR_USERNAME: ezydeploy"
-#   * GCR_PAT: 1Password: 'ezydeploy account on github.com' / 'ContainerRegistry PAT'
-#   * NUGET_SABRE_NEXUS_STAGING_API_KEY: 1Password: 'svc-ark-radixxezy' / 'NuGet API Key'
-#   * NEXUS_USER: 1Password: 'svc-ark-radixxezy' / 'user token name'
-#   * NEXUS_PASSWORD: 1Password: 'svc-ark-radixxezy' / 'pass code'
-#   * SCAN_USER: 1Password: 'svc-ark-radixxezy' / 'username'
-#   * SCAN_PASSWORD: 1Password: 'svc-ark-radixxezy' / 'promotion jenkins token (cicd)'
-#   * OCTOPUS_EZY_ONPREM_APIKEY: 1Password: 'Octopus Api Key (for GCP)' / 'password'
+#   * GCR_USERNAME: <your_github_username>
+#   * GCR_PAT: <your_PAT_value> / https://github.com/settings/tokens
+#   * NUGET_SABRE_NEXUS_STAGING_API_KEY: <your_Nexus_NuGet_api_key> / https://repository.sabre-gcp.com/#user/nugetapitoken
+#   * NEXUS_USER: 1Password: 'your_Nexus_user_token_name> / https://repository.sabre-gcp.com/#user/usertoken
+#   * NEXUS_PASSWORD: 1Password: 'your_Nexus_user_token_value> / https://repository.sabre-gcp.com/#user/usertoken
+#   * SCAN_USER: <your-SG-number>
+#   * SCAN_PASSWORD: <your_PromotionJenkins_token_value> / https://promote.repository.sabre-gcp.com/user/svc-ark-radixxezy@sgdcelab.sabre.com/configure 
+#   * OCTOPUS_SABRE_GKE_APIKEY: <your_Octopus_api_key> / https://ezy-octopus-server-radixx-ezyc-dev-ops.apps.dev-01.us-central1.dev.sabre-gcp.com/app#/Spaces-1/users/me/apiKeys
 #
 # * AWS secrets (only when needing to run tentancle from under tcagent. It's useful, when you build new image(s) and you don't want to wait until it's pushed to github and then downloaded directly to your machine)
 #   Obtain session token by "aws sts get-session-token --serial-number arn-of-your-mfa-device --token-code mfa-token"
@@ -42,12 +42,10 @@ Dir.mkdir(home_dot_ezy_build_env_dir) unless File.exists?(home_dot_ezy_build_env
 github_env_file = "#{home_dot_ezy_build_env_dir}/github_ezy.env"
 nexus_env_file = "#{home_dot_ezy_build_env_dir}/sabre_nexus.env"
 scan_env_file = "#{home_dot_ezy_build_env_dir}/sabre_scan.env"
-octopus_ezy_onprem_env_file = "#{home_dot_ezy_build_env_dir}/octopus_ezy_onprem.env"
 octopus_sabre_gke_env_file = "#{home_dot_ezy_build_env_dir}/octopus_sabre_gke.env"
 File.write(github_env_file, "GCR_USERNAME=#{ENV["GCR_USERNAME"]}\nGCR_PAT=#{ENV["GCR_PAT"]}") unless File.exists?(github_env_file)
 File.write(nexus_env_file, "NUGET_SABRE_NEXUS_STAGING_API_KEY=#{ENV["NUGET_SABRE_NEXUS_STAGING_API_KEY"]}\nNEXUS_USER=#{ENV["NEXUS_USER"]}\nNEXUS_PASSWORD=#{ENV["NEXUS_PASSWORD"]}") unless File.exists?(nexus_env_file)
 File.write(scan_env_file, "SCAN_USER=#{ENV["SCAN_USER"]}\nSCAN_PASSWORD=#{ENV["SCAN_PASSWORD"]}") unless File.exists?(scan_env_file)
-File.write(octopus_ezy_onprem_env_file, "OCTOPUS_APIKEY=#{ENV["OCTOPUS_EZY_ONPREM_APIKEY"]}") unless File.exists?(octopus_ezy_onprem_env_file)
 File.write(octopus_sabre_gke_env_file, "OCTOPUS_APIKEY=#{ENV["OCTOPUS_SABRE_GKE_APIKEY"]}") unless File.exists?(octopus_sabre_gke_env_file)
 
 # Write .env files for ezyDeploy

--- a/run-tcagent-win.rb
+++ b/run-tcagent-win.rb
@@ -3,7 +3,7 @@
 # * RUN_INNER_CONTAINERS_AS_ROOT=false. When mounting our sources into /app from Windows, passing the $(id -u):$(id -g) to inner containers work well - i.e.
 #   they don't complain about not enough permissions to create dirs or files.
 # * To preserve the history, we instruct it to be saved into mounted folder by HISTFILE env var, but also have to add "-e HISTCONTROL=histappend".
-#   This is because we firstly detach from session (in background) and attach to it via exec (so that we can attach to it later on). 
+#   This is because we firstly detach from session (in background) and attach to it via exec (so that we can attach to it later on).
 #   Also -it options has to be present, even in the first container start to allow the history to be saved to file.
 #
 # * Where to get secrets from?:
@@ -78,10 +78,11 @@ puts "CONTAINER_ENGINE: #{$container_engine}"
 container_name = "ezy-tc-agent-local-#{current_dir_name}-#{$container_engine}"
 tcagent_extra_env_vars = ($container_engine == "docker") ? "-e DOCKER_IN_DOCKER=start" : ""
 tcagent_image = ($container_engine == "docker") ? "ezy.teamcity.agent:2023.11.4-linux-sudo-6" : "ezy.teamcity.agent:2023.05.4-linux-1"
-# Podman: As a non-root container user, container images are stored under your home directory ($HOME/.local/share/containers/storage/), instead of /var/lib/containers.
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/managing_containers/finding_running_and_building_containers_with_podman_skopeo_and_buildah
-# Unfortunately, mounting this drive on Windwos (nfs fs) makes the directory owned by root, so not usable inside. The workaround would be to create
-# the volume on host system with buildagent as owner, however this would work only under linux.
+# * Podman: As a non-root container user, container images are stored under your home directory ($HOME/.local/share/containers/storage/), instead of /var/lib/containers.
+#   https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/managing_containers/finding_running_and_building_containers_with_podman_skopeo_and_buildah
+#   Unfortunately, mounting this drive on Windwos (nfs fs) makes the directory owned by root, so not usable inside. The workaround would be to create
+#   the volume on host system with buildagent as owner, however this would work only under linux.
+# * Docker: can't share /var/lib/docker between multiple containers (at least when using hyper-v)
 tcagent_mount_container_engine_dir = ($container_engine == "docker") ? "-v #{$container_engine}_volumes_#{current_dir_name}:/var/lib/docker" : ""
 
 task :default do


### PR DESCRIPTION
This is a pack of changes that were applied to CICD process. With this PR, we only update ezyBuild to latest version and the run-tcagent-win.rb script.

Major changes included:
GCP CI/CD - Prevent new build artifacts from replacing existing build artifacts with same name (RADEZYC-5149)
CI/CD: new tentacle & tcagent docker images to be tagged latest when pushed (RADEZYC-5151)
[CICD] Add cicd pipelines for self deployment of TC & Octopus (RADEZYC-5308)
[CICD] Security review (RADEZYC-5321)

NO CHANGES TO APPLICATIONS, just the build / deploy process upgraded to latest version.