### PR TITLE
feature/RADEZYC-5438/upgrade-ngptoolbox

### DIFF
--- a/build/restore-ezyBuild.csproj
+++ b/build/restore-ezyBuild.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <!-- We just need to pull the ezyBuild package for build process to work -->
   <ItemGroup>
-    <PackageReference Include="ezyBuild" Version="2.0.23" />
+    <PackageReference Include="ezyBuild" Version="2.0.27" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
upgrades ezyBuild to 2.0.27 that uses ezyGcpCli in version 1.0.4 which users latest NGP Toolbox that fixes problems with scans.