### PR TITLE
feature/RADEZYC-5375/fix-iqserver-vulnerabilities

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/package-lock.json
+++ b/src/Skoruba.IdentityServer4.Admin/package-lock.json
@@ -3007,8 +3007,8 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
@@ -3034,7 +3034,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },

--- a/src/Skoruba.IdentityServer4.Admin/package-lock.json
+++ b/src/Skoruba.IdentityServer4.Admin/package-lock.json
@@ -2360,7 +2360,7 @@
       "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.10",
+        "lodash": "~4.17.21",
         "minimatch": "~3.0.2"
       }
     },
@@ -2493,7 +2493,7 @@
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "node-sass": "^4.8.3",
         "plugin-error": "^1.0.1",
         "replace-ext": "^1.0.0",
@@ -3189,8 +3189,8 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "loud-rejection": {
@@ -3482,7 +3482,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
@@ -4251,7 +4251,7 @@
       "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
       "requires": {
         "glob": "^7.0.0",
-        "lodash": "^4.0.0",
+        "lodash": "^4.17.21",
         "scss-tokenizer": "^0.2.3",
         "yargs": "^13.3.2"
       },

--- a/src/Skoruba.IdentityServer4.Admin/package-lock.json
+++ b/src/Skoruba.IdentityServer4.Admin/package-lock.json
@@ -1831,7 +1831,7 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.6",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1861,7 +1861,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "1.2.6"
           }
         },
         "ms": {
@@ -2000,12 +2000,12 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "^1.2.6",
             "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.0",
+              "version": "1.2.6",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -3299,7 +3299,7 @@
         "decamelize": "^1.1.2",
         "loud-rejection": "^1.0.0",
         "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
+        "minimist": "^1.2.6",
         "normalize-package-data": "^2.3.4",
         "object-assign": "^4.0.1",
         "read-pkg-up": "^1.0.1",
@@ -3356,8 +3356,8 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
@@ -3386,7 +3386,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       }
     },
     "moment": {

--- a/src/Skoruba.IdentityServer4.Admin/package-lock.json
+++ b/src/Skoruba.IdentityServer4.Admin/package-lock.json
@@ -4150,7 +4150,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "~4.1.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       }
@@ -4917,8 +4917,8 @@
       }
     },
     "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
         "psl": "^1.1.28",

--- a/src/Skoruba.IdentityServer4.STS.Identity/package-lock.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/package-lock.json
@@ -2833,8 +2833,8 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
@@ -2860,7 +2860,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },

--- a/src/Skoruba.IdentityServer4.STS.Identity/package-lock.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/package-lock.json
@@ -1724,7 +1724,7 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.6",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1752,7 +1752,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "1.2.6"
           }
         },
         "ms": {
@@ -1897,12 +1897,12 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "^1.2.6",
             "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.0",
+              "version": "1.2.6",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -3075,7 +3075,7 @@
         "decamelize": "^1.1.2",
         "loud-rejection": "^1.0.0",
         "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
+        "minimist": "^1.2.6",
         "normalize-package-data": "^2.3.4",
         "object-assign": "^4.0.1",
         "read-pkg-up": "^1.0.1",
@@ -3132,8 +3132,8 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
@@ -3162,7 +3162,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       }
     },
     "ms": {

--- a/src/Skoruba.IdentityServer4.STS.Identity/package-lock.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/package-lock.json
@@ -3858,7 +3858,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "~4.1.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       }
@@ -4554,8 +4554,8 @@
       }
     },
     "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
         "psl": "^1.1.28",

--- a/src/Skoruba.IdentityServer4.STS.Identity/package-lock.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/package-lock.json
@@ -2220,7 +2220,7 @@
       "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.10",
+        "lodash": "~4.17.21",
         "minimatch": "~3.0.2"
       }
     },
@@ -2319,7 +2319,7 @@
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "node-sass": "^4.8.3",
         "plugin-error": "^1.0.1",
         "replace-ext": "^1.0.0",
@@ -2965,8 +2965,8 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "loud-rejection": {
@@ -3245,7 +3245,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
@@ -3959,7 +3959,7 @@
       "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
       "requires": {
         "glob": "^7.0.0",
-        "lodash": "^4.0.0",
+        "lodash": "^4.17.21",
         "scss-tokenizer": "^0.2.3",
         "yargs": "^13.3.2"
       },

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/package-lock.json
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/package-lock.json
@@ -3007,8 +3007,8 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
@@ -3034,7 +3034,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/package-lock.json
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/package-lock.json
@@ -2360,7 +2360,7 @@
       "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.10",
+        "lodash": "~4.17.21",
         "minimatch": "~3.0.2"
       }
     },
@@ -2493,7 +2493,7 @@
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "node-sass": "^4.8.3",
         "plugin-error": "^1.0.1",
         "replace-ext": "^1.0.0",
@@ -3189,8 +3189,8 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "loud-rejection": {
@@ -3482,7 +3482,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
@@ -4251,7 +4251,7 @@
       "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
       "requires": {
         "glob": "^7.0.0",
-        "lodash": "^4.0.0",
+        "lodash": "^4.17.21",
         "scss-tokenizer": "^0.2.3",
         "yargs": "^13.3.2"
       },

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/package-lock.json
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/package-lock.json
@@ -1831,7 +1831,7 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.6",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1861,7 +1861,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "1.2.6"
           }
         },
         "ms": {
@@ -2000,12 +2000,12 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "^1.2.6",
             "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.0",
+              "version": "1.2.6",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -3299,7 +3299,7 @@
         "decamelize": "^1.1.2",
         "loud-rejection": "^1.0.0",
         "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
+        "minimist": "^1.2.6",
         "normalize-package-data": "^2.3.4",
         "object-assign": "^4.0.1",
         "read-pkg-up": "^1.0.1",
@@ -3356,8 +3356,8 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
@@ -3386,7 +3386,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       }
     },
     "moment": {

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/package-lock.json
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/package-lock.json
@@ -4150,7 +4150,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "~4.1.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       }
@@ -4917,8 +4917,8 @@
       }
     },
     "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
         "psl": "^1.1.28",

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.STS.Identity/package-lock.json
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.STS.Identity/package-lock.json
@@ -2846,7 +2846,7 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
-      "version": "0.2.3",
+      "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
@@ -2873,7 +2873,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.STS.Identity/package-lock.json
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.STS.Identity/package-lock.json
@@ -2233,7 +2233,7 @@
       "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.10",
+        "lodash": "~4.17.21",
         "minimatch": "~3.0.2"
       }
     },
@@ -2332,7 +2332,7 @@
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "node-sass": "^4.8.3",
         "plugin-error": "^1.0.1",
         "replace-ext": "^1.0.0",
@@ -2978,8 +2978,8 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "loud-rejection": {
@@ -3258,7 +3258,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
@@ -3972,7 +3972,7 @@
       "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
       "requires": {
         "glob": "^7.0.0",
-        "lodash": "^4.0.0",
+        "lodash": "^4.17.21",
         "scss-tokenizer": "^0.2.3",
         "yargs": "^13.3.2"
       },

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.STS.Identity/package-lock.json
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.STS.Identity/package-lock.json
@@ -1729,7 +1729,7 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.6",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1759,7 +1759,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "1.2.6"
           }
         },
         "ms": {
@@ -1905,12 +1905,12 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "^1.2.6",
             "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.0",
+              "version": "1.2.6",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -3088,7 +3088,7 @@
         "decamelize": "^1.1.2",
         "loud-rejection": "^1.0.0",
         "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
+        "minimist": "^1.2.6",
         "normalize-package-data": "^2.3.4",
         "object-assign": "^4.0.1",
         "read-pkg-up": "^1.0.1",
@@ -3145,8 +3145,8 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
@@ -3175,7 +3175,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       }
     },
     "ms": {

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.STS.Identity/package-lock.json
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.STS.Identity/package-lock.json
@@ -3871,7 +3871,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "~4.1.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       }
@@ -4567,8 +4567,8 @@
       }
     },
     "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
         "psl": "^1.1.28",


### PR DESCRIPTION
Upgraded following js components in package.lock to the lowest, passing versions:
* minimist
* tough-cookie
* lodash
* json-schema