### PR TITLE
fb/dd-tracer-upgrade-3-4-0

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Dockerfile
+++ b/src/Skoruba.IdentityServer4.Admin/Dockerfile
@@ -49,7 +49,7 @@ RUN --mount=type=secret,id=github_ezy,uid=1000,gid=1000,uid=1000,gid=1000,dst=/e
 
 # ---------------------
 # Final runtime image for GCP
-FROM ghcr.io/ezywebwerkstaden/ezy.ubi8.dotnet-31-runtime:3.1-1.0.18 as gcp
+FROM ghcr.io/ezywebwerkstaden/ezy.ubi8.dotnet-31-runtime:3.1-1.0.19 as gcp
 LABEL se.ezy.project=identityserver-admin \
   se.ezy.image-purpose=dist
 
@@ -66,7 +66,7 @@ LABEL se.ezy.project=identityserver-admin \
   se.ezy.image-purpose=dist
 
 ## DataDog .NET Tracer
-ARG TRACER_VERSION=3.2.0
+ARG TRACER_VERSION=3.4.0
 RUN curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb && \
     dpkg -i ./datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb
 ENV CORECLR_ENABLE_PROFILING=1 \

--- a/src/Skoruba.IdentityServer4.STS.Identity/Dockerfile
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Dockerfile
@@ -46,7 +46,7 @@ RUN --mount=type=secret,id=github_ezy,uid=1000,gid=1000,uid=1000,gid=1000,dst=/e
 
 # ---------------------
 # Final runtime image for GCP
-FROM ghcr.io/ezywebwerkstaden/ezy.ubi8.dotnet-31-runtime:3.1-1.0.18 as gcp
+FROM ghcr.io/ezywebwerkstaden/ezy.ubi8.dotnet-31-runtime:3.1-1.0.19 as gcp
 LABEL se.ezy.project=identityserver-sts-identity \
   se.ezy.image-purpose=dist
 
@@ -63,7 +63,7 @@ LABEL se.ezy.project=identityserver-sts-identity \
   se.ezy.image-purpose=dist
 
 ## DataDog .NET Tracer
-ARG TRACER_VERSION=3.2.0
+ARG TRACER_VERSION=3.4.0
 RUN curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb && \
     dpkg -i ./datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb
 ENV CORECLR_ENABLE_PROFILING=1 \


### PR DESCRIPTION
Upgrade Datadog Tracer to 3.4.0. Also, upgrade ezy.ubi image to a version that contains tracer upgraded for gcp