### PR TITLE
RADEZYC-6554 :sparkles: Update ubi runtime image from *.19 to *.22

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Dockerfile
+++ b/src/Skoruba.IdentityServer4.Admin/Dockerfile
@@ -49,7 +49,7 @@ RUN --mount=type=secret,id=github_ezy,uid=1000,gid=1000,uid=1000,gid=1000,dst=/e
 
 # ---------------------
 # Final runtime image for GCP
-FROM ghcr.io/ezywebwerkstaden/ezy.ubi8.dotnet-31-runtime:3.1-1.0.19 as gcp
+FROM ghcr.io/ezywebwerkstaden/ezy.ubi8.dotnet-31-runtime:3.1-1.0.22 as gcp
 LABEL se.ezy.project=identityserver-admin \
   se.ezy.image-purpose=dist
 

--- a/src/Skoruba.IdentityServer4.STS.Identity/Dockerfile
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Dockerfile
@@ -46,7 +46,7 @@ RUN --mount=type=secret,id=github_ezy,uid=1000,gid=1000,uid=1000,gid=1000,dst=/e
 
 # ---------------------
 # Final runtime image for GCP
-FROM ghcr.io/ezywebwerkstaden/ezy.ubi8.dotnet-31-runtime:3.1-1.0.19 as gcp
+FROM ghcr.io/ezywebwerkstaden/ezy.ubi8.dotnet-31-runtime:3.1-1.0.22 as gcp
 LABEL se.ezy.project=identityserver-sts-identity \
   se.ezy.image-purpose=dist
 


### PR DESCRIPTION
which includes latest DD tracer